### PR TITLE
Add one-click CSV export for tables and query results

### DIFF
--- a/app/server/core/data_models.py
+++ b/app/server/core/data_models.py
@@ -80,3 +80,8 @@ class HealthCheckResponse(BaseModel):
     tables_count: int
     version: str = "1.0.0"
     uptime_seconds: float
+# Export Models
+class QueryExportRequest(BaseModel):
+    columns: List[str]
+    results: List[Dict[str, Any]]
+    filename: Optional[str] = "query_results"


### PR DESCRIPTION
## Summary
- Add `GET /api/table/{table_name}/export` endpoint for table CSV export
- Add `POST /api/query/export` endpoint for query results CSV export  
- Add download button to the left of 'x' icon for available tables
- Add download button to the left of 'Hide' button for query results
- Add `QueryExportRequest` model for export requests

## Security
- SQL injection protection via `validate_identifier()`
- Table existence check via `check_table_exists()`

## Test Results
- Unit Tests: **67/67 passed**
- E2E Tests: **passed**

## Test plan
- [x] All unit tests pass
- [x] E2E tests pass
- [ ] Manual test: Upload table and click download button
- [ ] Manual test: Run query and click download results button

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)